### PR TITLE
Add surefire plugin to Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+				<configuration>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Part of #4.

Surefire plugin allows tests to be found and run during automated builds by Maven.