### PR TITLE
Added login/logout with OAuth2, through GitHub.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,15 @@
 			<groupId>org.webjars</groupId>
 			<artifactId>webjars-locator-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>js-cookie</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/popescu/andrei/anfeld/UserController.java
+++ b/src/main/java/popescu/andrei/anfeld/UserController.java
@@ -1,0 +1,23 @@
+package popescu.andrei.anfeld;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+public class UserController {
+
+    @GetMapping("/user")
+    public Map<String, Object> user(@AuthenticationPrincipal OAuth2User principal) {
+        return Collections.singletonMap("name", principal.getAttribute("name"));
+    }
+
+    @GetMapping("/logout")
+    public String showRegistrationForm() {
+        return "redirect:/";
+    }
+}

--- a/src/main/java/popescu/andrei/anfeld/config/SecurityConfig.java
+++ b/src/main/java/popescu/andrei/anfeld/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
@@ -25,13 +26,16 @@ public class SecurityConfig {
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/logout").permitAll()
                         .requestMatchers("/styles/*").permitAll()
+                        .requestMatchers("/js/*").permitAll()
                         .requestMatchers("/webjars/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
+                .logout(logout -> logout.logoutSuccessUrl("/").permitAll())
                 .oauth2Login(Customizer.withDefaults());
 
         return http.build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,5 +6,5 @@ spring:
       client:
         registration:
           github:
-            clientId: github-client-id
-            clientSecret: github-client-secret
+            clientId: Ov23lix9FI1R9LQaD8WJ
+            clientSecret: f8564256351d9a65cc03cb216df933364e0deaea

--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -1,0 +1,5 @@
+document.addEventListener("DOMContentLoaded", function () {
+    $.get("/user", function(data) {
+        $("#user").text(data.name); // populate username in navbar
+    });
+});

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,16 @@
+<header xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+    <script type="text/javascript" th:src="@{/js/header.js}"></script>
+    <nav sec:authorize="!isAuthenticated()">
+        Login with GitHub: <a href="/oauth2/authorization/github">click here</a>
+    </nav>
+    <nav sec:authorize="isAuthenticated()">
+        Logged in as: <span id="user"></span> (<span sec:authentication="name"></span>)
+        <div>
+            <form th:action="@{/logout}" method="post">
+                <div><input type="submit" value="Log Out" class="btn btn-primary"/></div>
+            </form>
+<!--            <button th:onclick="logout()" id="logout-btn" class="btn btn-primary">Logout</button>-->
+        </div>
+    </nav>
+    <hr/>
+</header>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,10 +3,14 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Mini Survey Monkey - Welcome</title>
-    <link rel="stylesheet" th:href="@{/styles/style.css}">
+    <title>Anfeld Character Builder</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
 </head>
 <body>
+    <div th:replace="fragments/header"></div>
     <h1>Welcome!</h1>
     <p>Test text: <span th:text="${test}"></span></p>
 </body>


### PR DESCRIPTION
Resolves #3.
OAuth2 is done via GitHub. TBD where secrets are stored long-term.
The homepage's header now changes depending on whether the user is logged in or not.
If logged in:
- shows GitHub username as well as internal user name (for debug only, it's a number)
- shows a logout button
If logged out:
- shows a login link that will prompt for authentication via GitHub.

The logout and login will redirect to the home page once successful.

This header is written as a fragment so it can be reused on every page that needs it.