### PR TITLE
Add ability to create characters

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,14 +18,28 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 22.x ]
+        mongodb-version: [ '7.0' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - name: git checkout
+      uses: actions/checkout@v4
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.11.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 22.x ]
-        mongodb-version: [ '7.0' ]
 
     steps:
     - name: git checkout
@@ -32,14 +28,14 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 22.x
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 22.x
 
     - name: Start MongoDB
       uses: supercharge/mongodb-github-action@1.11.0
       with:
-        mongodb-version: ${{ matrix.mongodb-version }}
+        mongodb-version: 7.0
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<junit.jupiter.version>5.7.0</junit.jupiter.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -45,6 +46,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.17.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
@@ -69,7 +75,24 @@
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.12.0</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -100,6 +123,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/popescu/andrei/anfeld/AnfeldCharacterBuilderApplication.java
+++ b/src/main/java/popescu/andrei/anfeld/AnfeldCharacterBuilderApplication.java
@@ -9,5 +9,4 @@ public class AnfeldCharacterBuilderApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(AnfeldCharacterBuilderApplication.class, args);
 	}
-
 }

--- a/src/main/java/popescu/andrei/anfeld/controller/CharacterController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/CharacterController.java
@@ -1,0 +1,46 @@
+package popescu.andrei.anfeld.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import popescu.andrei.anfeld.model.WildcardCharacter;
+import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
+
+import java.util.List;
+
+@Controller
+public class CharacterController {
+
+    @Autowired
+    WildcardCharacterRepository characterRepository;
+
+    @GetMapping("/createCharacterForm")
+    public String createCharacterForm(Model model, @AuthenticationPrincipal OAuth2User principal) {
+        model.addAttribute("character", new WildcardCharacter());
+        return "createCharacter";
+    }
+
+    @PostMapping("/createCharacter")
+    public String createCharacter(
+            @ModelAttribute("character") WildcardCharacter character,
+            @AuthenticationPrincipal OAuth2User principal) {
+        character.setOwnerId(principal.getName());
+        characterRepository.save(character);
+        return "redirect:/";
+    }
+
+    @GetMapping("characters/{ownerId}")
+    @ResponseBody
+    public List<WildcardCharacter> getCharactersForOwner(
+            Model model,
+            @PathVariable String ownerId,
+            @AuthenticationPrincipal OAuth2User principal) {
+        if (!ownerId.equals(principal.getName())) {
+            return null; // trying to access another user's characters
+        }
+        return characterRepository.findCharactersByOwnerId(ownerId);
+    }
+}

--- a/src/main/java/popescu/andrei/anfeld/controller/HomepageController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/HomepageController.java
@@ -1,4 +1,4 @@
-package popescu.andrei.anfeld;
+package popescu.andrei.anfeld.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/popescu/andrei/anfeld/controller/UserController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/UserController.java
@@ -1,4 +1,4 @@
-package popescu.andrei.anfeld;
+package popescu.andrei.anfeld.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -13,7 +13,8 @@ public class UserController {
 
     @GetMapping("/user")
     public Map<String, Object> user(@AuthenticationPrincipal OAuth2User principal) {
-        return Collections.singletonMap("name", principal.getAttribute("name"));
+        // getAttribute("name") gets the name from GitHub, as opposed to getName() which gets a number
+        return Collections.singletonMap("name", principal.getAttribute("name").toString() + " (" + principal.getName() + ")");
     }
 
     @GetMapping("/logout")

--- a/src/main/java/popescu/andrei/anfeld/controller/UserController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
     }
 
     @GetMapping("/logout")
-    public String showRegistrationForm() {
+    public String logout() {
         return "redirect:/";
     }
 }

--- a/src/main/java/popescu/andrei/anfeld/controller/UserController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/UserController.java
@@ -3,18 +3,24 @@ package popescu.andrei.anfeld.controller;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
 public class UserController {
 
     @GetMapping("/user")
+    @ResponseBody
     public Map<String, Object> user(@AuthenticationPrincipal OAuth2User principal) {
         // getAttribute("name") gets the name from GitHub, as opposed to getName() which gets a number
-        return Collections.singletonMap("name", principal.getAttribute("name").toString() + " (" + principal.getName() + ")");
+        var map = new HashMap<String, Object>();
+        map.put("name", principal.getAttribute("name").toString());
+        map.put("id", principal.getName());
+        return map;
     }
 
     @GetMapping("/logout")

--- a/src/main/java/popescu/andrei/anfeld/model/WildcardCharacter.java
+++ b/src/main/java/popescu/andrei/anfeld/model/WildcardCharacter.java
@@ -1,0 +1,46 @@
+package popescu.andrei.anfeld.model;
+
+import org.springframework.data.annotation.Id;
+
+public class WildcardCharacter {
+
+    @Id
+    private String id;
+
+    private String ownerId = null;
+    private String characterName;
+
+    public WildcardCharacter() {}
+
+    public WildcardCharacter(String ownerId) {
+        this();
+        this.ownerId = ownerId;
+    }
+
+    public WildcardCharacter(String ownerId, String characterName) {
+        this(ownerId);
+        this.characterName = characterName;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        if (this.ownerId == null) {
+            this.ownerId = ownerId;
+        }
+    }
+
+    public String getCharacterName() {
+        return characterName;
+    }
+
+    public void setCharacterName(String characterName) {
+        this.characterName = characterName;
+    }
+}

--- a/src/main/java/popescu/andrei/anfeld/repository/WildcardCharacterRepository.java
+++ b/src/main/java/popescu/andrei/anfeld/repository/WildcardCharacterRepository.java
@@ -1,0 +1,13 @@
+package popescu.andrei.anfeld.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import popescu.andrei.anfeld.model.WildcardCharacter;
+
+import java.util.List;
+
+public interface WildcardCharacterRepository extends MongoRepository<WildcardCharacter, String> {
+
+    WildcardCharacter findCharacterById(String id);
+
+    List<WildcardCharacter> findCharactersByOwnerId(String ownerId);
+}

--- a/src/main/resources/templates/createCharacter.html
+++ b/src/main/resources/templates/createCharacter.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Create Wildcard Character</title>
     <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
     <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
@@ -14,8 +14,8 @@
     <h1>Create a new Wildcard character</h1>
     <form th:action="@{/createCharacter}" th:object="${character}" method="post">
         <label for="characterName">Character name:</label>
-        <input type="text" id="characterName" th:field="*{characterName}" required>
-        <input type="submit" value="Create">
+        <input type="text" id="characterName" th:field="*{characterName}" th:required="required"/>
+        <input type="submit" value="Create"/>
     </form>
 </body>
 </html>

--- a/src/main/resources/templates/createCharacter.html
+++ b/src/main/resources/templates/createCharacter.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Create Wildcard Character</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
+</head>
+<body>
+    <div th:replace="fragments/header"></div>
+    <h1>Create a new Wildcard character</h1>
+    <form th:action="@{/createCharacter}" th:object="${character}" method="post">
+        <label for="characterName">Character name:</label>
+        <input type="text" id="characterName" th:field="*{characterName}" required>
+        <input type="submit" value="Create">
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"/>
     <title>Anfeld Character Builder</title>
     <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
     <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>

--- a/src/test/java/popescu/andrei/anfeld/controller/CharacterControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/CharacterControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,54 +15,45 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
 @ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-public class UserControllerTest {
+public class CharacterControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    /**
-     * Tests that the /user endpoint correctly returns user information when a user is logged in.
-     * @throws Exception if the endpoint can't be accessed at all
-     */
+    @Mock
+    private WildcardCharacterRepository characterRepository;
+
     @Test
     @DirtiesContext
-    public void testGetUser() throws Exception {
+    public void testCreateCharacterForm() throws Exception {
         // the name of the default user is "user"
         // set the name attribute (display name) manually
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/user")
+        mockMvc.perform(MockMvcRequestBuilders.get("/createCharacterForm")
                         .with(csrf())
                         .with(oauth2Login().attributes(attr -> attr.put("name", "displayName")))
-                        .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.TEXT_HTML))
                 .andExpect(status().is2xxSuccessful())
-                .andReturn();
-        // check that the response is correct
-        var objectMapper = new ObjectMapper();
-        var response = result.getResponse().getContentAsString();
-        Map<String, Object> map = objectMapper.readValue(response, new TypeReference<>() {});
-        assertEquals("displayName", map.get("name"));
-        assertEquals("user", map.get("id"));
+                .andExpect(xpath("//input[@id=\"characterName\"]").exists());
     }
 
-    /**
-     * Tests that the /user endpoint returns an unauthorized error code when a user that isn't logged in accesses it.
-     * @throws Exception if the endpoint can't be accessed at all
-     */
     @Test
     @DirtiesContext
-    public void testGetUserNotLoggedInUnauthorized() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/user")
+    public void testCreateCharacterFormNotLoggedInUnauthorized() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/createCharacterForm")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());
     }

--- a/src/test/java/popescu/andrei/anfeld/controller/CharacterControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/CharacterControllerTest.java
@@ -1,10 +1,8 @@
 package popescu.andrei.anfeld.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,8 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import popescu.andrei.anfeld.model.WildcardCharacter;
 import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
 
 import java.util.Map;
@@ -22,8 +20,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(SpringExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -31,11 +28,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class CharacterControllerTest {
 
+    private static final String DEFAULT_USER_ID = "user"; // as defined by the oauthlogin test user
+
     @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @Autowired
     private WildcardCharacterRepository characterRepository;
+
+    @BeforeEach
+    public void setup() {
+        characterRepository.deleteAll();
+    }
 
     @Test
     @DirtiesContext
@@ -54,6 +58,36 @@ public class CharacterControllerTest {
     @DirtiesContext
     public void testCreateCharacterFormNotLoggedInUnauthorized() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/createCharacterForm")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DirtiesContext
+    public void testCreateCharacter() throws Exception {
+        final String characterName = "testCharacterName";
+        var character = new WildcardCharacter();
+        character.setCharacterName(characterName);
+        mockMvc.perform(MockMvcRequestBuilders.post("/createCharacter")
+                        .flashAttr("character", character)
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attr -> attr.put("name", "displayName"))))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/")); // test redirect to index, this may change
+        // confirm character was created with correct ID
+        var addedCharacter = characterRepository.findCharacterById(character.getId());
+        assertEquals(DEFAULT_USER_ID, addedCharacter.getOwnerId());
+        assertEquals(characterName, addedCharacter.getCharacterName());
+    }
+
+    @Test
+    @DirtiesContext
+    public void testCreateCharacterNotLoggedInUnauthorized() throws Exception {
+        final String characterName = "testCharacterName";
+        var character = new WildcardCharacter();
+        character.setCharacterName(characterName);
+        mockMvc.perform(MockMvcRequestBuilders.post("/createCharacter")
+                        .flashAttr("character", character)
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());
     }

--- a/src/test/java/popescu/andrei/anfeld/controller/UserControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/UserControllerTest.java
@@ -1,0 +1,60 @@
+package popescu.andrei.anfeld.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.experimental.results.ResultMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DirtiesContext
+    @WithMockUser(username = "user1")
+    public void testGetUser() throws Exception {
+        // the name of the default user is "user"
+        // set the name attribute (display name) manually
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/user")
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attr -> attr.put("name", "displayName")))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        // check that the response is correct
+        var objectMapper = new ObjectMapper();
+        var response = result.getResponse().getContentAsString();
+        Map<String, Object> map = objectMapper.readValue(response, new TypeReference<>() {});
+        assertEquals("displayName", map.get("name"));
+        assertEquals("user", map.get("id"));
+    }
+}


### PR DESCRIPTION
Authenticated users can now create characters.
- The `/createCharacterForm` endpoint displays a form asking for the character's name.
- The `/createCharacter` endpoint creates the character in the database, under the ownership of the authenticated user. This endpoint is called by submitting the form at `/createCharacterForm`.

Both endpoints can't be accessed (401) if not authenticated as a user.
No navigation leads to the form yet.

Tests added for the `/user` endpoint and the new endpoints.