### PR TITLE
Add page for viewing character lists, and tests for the new endpoints

### DIFF
--- a/src/main/java/popescu/andrei/anfeld/controller/CharacterManagementController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/CharacterManagementController.java
@@ -1,0 +1,32 @@
+package popescu.andrei.anfeld.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import popescu.andrei.anfeld.model.WildcardCharacter;
+import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
+
+@Controller
+public class CharacterManagementController {
+
+    @Autowired
+    WildcardCharacterRepository characterRepository;
+
+    @GetMapping("/createCharacterForm")
+    public String createCharacterForm(Model model, @AuthenticationPrincipal OAuth2User principal) {
+        model.addAttribute("character", new WildcardCharacter());
+        return "createCharacter";
+    }
+
+    @PostMapping("/createCharacter")
+    public String createCharacter(
+            @ModelAttribute("character") WildcardCharacter character,
+            @AuthenticationPrincipal OAuth2User principal) {
+        character.setOwnerId(principal.getName());
+        characterRepository.save(character);
+        return "redirect:/";
+    }
+}

--- a/src/main/java/popescu/andrei/anfeld/controller/CharacterViewController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/CharacterViewController.java
@@ -5,32 +5,20 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import popescu.andrei.anfeld.model.WildcardCharacter;
 import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
 
+import java.util.LinkedList;
 import java.util.List;
 
 @Controller
-public class CharacterController {
+public class CharacterViewController {
 
     @Autowired
     WildcardCharacterRepository characterRepository;
-
-    @GetMapping("/createCharacterForm")
-    public String createCharacterForm(Model model, @AuthenticationPrincipal OAuth2User principal) {
-        model.addAttribute("character", new WildcardCharacter());
-        return "createCharacter";
-    }
-
-    @PostMapping("/createCharacter")
-    public String createCharacter(
-            @ModelAttribute("character") WildcardCharacter character,
-            @AuthenticationPrincipal OAuth2User principal) {
-        character.setOwnerId(principal.getName());
-        characterRepository.save(character);
-        return "redirect:/";
-    }
 
     @GetMapping("characters/{ownerId}")
     @ResponseBody
@@ -39,8 +27,16 @@ public class CharacterController {
             @PathVariable String ownerId,
             @AuthenticationPrincipal OAuth2User principal) {
         if (!ownerId.equals(principal.getName())) {
-            return null; // trying to access another user's characters
+            return new LinkedList<>(); // trying to access another user's characters is not allowed
         }
         return characterRepository.findCharactersByOwnerId(ownerId);
+    }
+
+    @GetMapping("characterList")
+    public String viewCharacters(
+            Model model,
+            @AuthenticationPrincipal OAuth2User principal) {
+        model.addAttribute("characters", characterRepository.findCharactersByOwnerId(principal.getName()));
+        return "viewCharacters";
     }
 }

--- a/src/main/resources/static/js/viewCharacters.js
+++ b/src/main/resources/static/js/viewCharacters.js
@@ -1,0 +1,3 @@
+document.addEventListener("DOMContentLoaded", function () {
+
+});

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,6 +1,6 @@
 <header xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
     <script type="text/javascript" th:src="@{/js/header.js}"></script>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark bg-gradient">
         <div class="container-fluid">
             <a class="navbar-brand" href="#">Anfeld Character Builder</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -9,6 +9,9 @@
             <div id="navbarContent" class="collapse navbar-collapse">
                 <div class="navbar-nav me-auto">
                     <a class="nav-link active" aria-current="page" href="/">Home</a>
+                </div>
+                <div class="navbar-nav me-auto">
+                    <a class="nav-link active" aria-current="page" href="/characterList">Characters</a>
                 </div>
                 <div class="navbar-nav ml-auto"> <!-- Right-aligned navbar elements -->
                     <!-- Login/logout buttons -->

--- a/src/main/resources/templates/viewCharacters.html
+++ b/src/main/resources/templates/viewCharacters.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>View Characters</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
+</head>
+<body>
+<div th:replace="fragments/header"></div>
+<h1>View characters</h1>
+<p>Create a <a href="/createCharacterForm">new character</a></p>
+<div th:each="character : ${characters}" id="characterList">
+    <div class="bg-primary text-white m-2 p-2">
+        <h2 th:text="${character.characterName}"></h2>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/popescu/andrei/anfeld/controller/CharacterManagementControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/CharacterManagementControllerTest.java
@@ -15,8 +15,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import popescu.andrei.anfeld.model.WildcardCharacter;
 import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
 
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
@@ -26,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-public class CharacterControllerTest {
+public class CharacterManagementControllerTest {
 
     private static final String DEFAULT_USER_ID = "user"; // as defined by the oauthlogin test user
 

--- a/src/test/java/popescu/andrei/anfeld/controller/CharacterViewControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/CharacterViewControllerTest.java
@@ -1,0 +1,108 @@
+package popescu.andrei.anfeld.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import popescu.andrei.anfeld.model.WildcardCharacter;
+import popescu.andrei.anfeld.repository.WildcardCharacterRepository;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CharacterViewControllerTest {
+
+    private static final String DEFAULT_USER_ID = "user"; // as defined by the oauthlogin test user
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WildcardCharacterRepository characterRepository;
+
+    @BeforeEach
+    public void setup() {
+        characterRepository.deleteAll();
+        var character1 = new WildcardCharacter(DEFAULT_USER_ID, "Test1");
+        var character2 = new WildcardCharacter(DEFAULT_USER_ID, "Test2");
+        var character3 = new WildcardCharacter(DEFAULT_USER_ID + "1", "Test3");
+        characterRepository.save(character1);
+        characterRepository.save(character2);
+        characterRepository.save(character3);
+    }
+
+    @Test
+    @DirtiesContext
+    public void testGetCharactersForUser() throws Exception {
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/characters/" + DEFAULT_USER_ID)
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attr -> attr.put("name", "displayName"))))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var objectMapper = new ObjectMapper();
+        var response = result.getResponse().getContentAsString();
+        List<WildcardCharacter> characterList = objectMapper.readValue(response, new TypeReference<>() {});
+        var characterNames = characterList.stream().map(WildcardCharacter::getCharacterName).toList();
+        assertTrue(characterNames.contains("Test1"));
+        assertTrue(characterNames.contains("Test2"));
+        assertFalse(characterNames.contains("Test3"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void testGetCharacterWithoutUserUnauthorized() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/characters/user")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DirtiesContext
+    public void testGetCharacterForOtherUserEmpty() throws Exception {
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/characters/" + DEFAULT_USER_ID + "1")
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attr -> attr.put("name", "displayName"))))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var objectMapper = new ObjectMapper();
+        var response = result.getResponse().getContentAsString();
+        List<WildcardCharacter> characterList = objectMapper.readValue(response, new TypeReference<>() {});
+        var characterNames = characterList.stream().map(WildcardCharacter::getCharacterName).toList();
+        assertFalse(characterNames.contains("Test1"));
+        assertFalse(characterNames.contains("Test2"));
+    }
+
+    @Test
+    @DirtiesContext
+    public void testViewCharacters() throws Exception {
+        // the name of the default user is "user"
+        mockMvc.perform(MockMvcRequestBuilders.get("/characterList")
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attr -> attr.put("name", "displayName")))
+                        .accept(MediaType.TEXT_HTML))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(view().name("viewCharacters"))
+                .andExpect(xpath("//h2[text()='Test1']").exists())
+                .andExpect(xpath("//h2[text()='Test2']").exists())
+                .andExpect(xpath("//h2[text()='Test3']").doesNotExist());
+    }
+}


### PR DESCRIPTION
The navbar now includes a link to view characters. The character view page includes a link to create a new character, as well as the name (for now) of each character the user owns.
New endpoints (all require authentication):
- `/characterList`: shows all characters the user owns
- `/characters/{owner}`: returns all characters owned by the user as JSON, or none if the user is not the logged-in user

Also added tests for the new endpoints and renamed some controllers.
Resolves #10.