### PR TITLE
Error page improvements

### DIFF
--- a/src/main/java/popescu/andrei/anfeld/config/SecurityConfig.java
+++ b/src/main/java/popescu/andrei/anfeld/config/SecurityConfig.java
@@ -1,17 +1,27 @@
 package popescu.andrei.anfeld.config;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
@@ -33,7 +43,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(e -> e
-                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .defaultAuthenticationEntryPointFor(
+                                (request, response, authException) -> response.sendError(401, "error"),
+                                new AntPathRequestMatcher("/api/**"))
                 )
                 .logout(logout -> logout.logoutSuccessUrl("/").permitAll())
                 .oauth2Login(Customizer.withDefaults());

--- a/src/main/java/popescu/andrei/anfeld/controller/ApplicationErrorController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/ApplicationErrorController.java
@@ -1,0 +1,28 @@
+package popescu.andrei.anfeld.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class ApplicationErrorController implements ErrorController {
+
+    @RequestMapping("/error")
+    public String handleError(HttpServletRequest request) {
+        var status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE); // get HTTP status code
+        if (status != null) {
+            var statusCode = Integer.parseInt(status.toString());
+            if (statusCode == HttpStatus.NOT_FOUND.value()) {
+                return "error/error-404";
+            } else if (statusCode == HttpStatus.UNAUTHORIZED.value()) {
+                return "error/error-401";
+            } else if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+                return "error/error"; // add a unique page later
+            }
+        }
+        return "error/error";
+    }
+}

--- a/src/main/java/popescu/andrei/anfeld/controller/CharacterManagementController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/CharacterManagementController.java
@@ -21,7 +21,7 @@ public class CharacterManagementController {
         return "createCharacter";
     }
 
-    @PostMapping("/createCharacter")
+    @PostMapping("/api/createCharacter")
     public String createCharacter(
             @ModelAttribute("character") WildcardCharacter character,
             @AuthenticationPrincipal OAuth2User principal) {

--- a/src/main/java/popescu/andrei/anfeld/controller/CharacterViewController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/CharacterViewController.java
@@ -20,7 +20,7 @@ public class CharacterViewController {
     @Autowired
     WildcardCharacterRepository characterRepository;
 
-    @GetMapping("characters/{ownerId}")
+    @GetMapping("/api/characters/{ownerId}")
     @ResponseBody
     public List<WildcardCharacter> getCharactersForOwner(
             Model model,
@@ -32,7 +32,7 @@ public class CharacterViewController {
         return characterRepository.findCharactersByOwnerId(ownerId);
     }
 
-    @GetMapping("characterList")
+    @GetMapping("/characterList")
     public String viewCharacters(
             Model model,
             @AuthenticationPrincipal OAuth2User principal) {

--- a/src/main/java/popescu/andrei/anfeld/controller/UserController.java
+++ b/src/main/java/popescu/andrei/anfeld/controller/UserController.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @RestController
 public class UserController {
 
-    @GetMapping("/user")
+    @GetMapping("/api/user")
     @ResponseBody
     public Map<String, Object> user(@AuthenticationPrincipal OAuth2User principal) {
         // getAttribute("name") gets the name from GitHub, as opposed to getName() which gets a number

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ spring:
           github:
             clientId: Ov23lix9FI1R9LQaD8WJ
             clientSecret: f8564256351d9a65cc03cb216df933364e0deaea
+server:
+  error:
+    whitelabel:
+      enabled: false # disable the Whitelabel error page to use a custom one

--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", function () {
-    $.get("/user", function(data) {
+    $.get("/api/user", function(data) {
         $("#user").text(data.name); // populate username in navbar
     });
 });

--- a/src/main/resources/templates/error/error-401.html
+++ b/src/main/resources/templates/error/error-401.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Unauthorized</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
+</head>
+<body>
+<div th:replace="fragments/header"></div>
+<h1>Unauthorized (Error 401)</h1>
+<p>You do not have permission to access the page you attempted to visit. You may need to <a href="/login">log in</a></p>
+<p>Return to the <a href="/">homepage</a>.</p>
+</body>
+</html>

--- a/src/main/resources/templates/error/error-404.html
+++ b/src/main/resources/templates/error/error-404.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Page not found</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
+</head>
+<body>
+<div th:replace="fragments/header"></div>
+<h1>Page not Found (Error 404)</h1>
+<p>The page you attempted to visit does not exist.</p>
+<p>Return to the <a href="/">homepage</a>.</p>
+</body>
+</html>

--- a/src/main/resources/templates/error/error-500.html
+++ b/src/main/resources/templates/error/error-500.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Error</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
+</head>
+<body>
+<div th:replace="fragments/header"></div>
+<h1>Something went wrong</h1>
+<p>Return to the <a href="/">homepage</a>.</p>
+</body>
+</html>

--- a/src/main/resources/templates/error/error.html
+++ b/src/main/resources/templates/error/error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Error</title>
+    <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/css/bootstrap.min.css"/>
+    <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/webjars/js-cookie/js.cookie.js"></script>
+</head>
+<body>
+<div th:replace="fragments/header"></div>
+<h1>Something went wrong</h1>
+<p>Return to the <a href="/">homepage</a>.</p>
+</body>
+</html>

--- a/src/test/java/popescu/andrei/anfeld/controller/CharacterManagementControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/CharacterManagementControllerTest.java
@@ -66,7 +66,7 @@ public class CharacterManagementControllerTest {
         final String characterName = "testCharacterName";
         var character = new WildcardCharacter();
         character.setCharacterName(characterName);
-        mockMvc.perform(MockMvcRequestBuilders.post("/createCharacter")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/createCharacter")
                         .flashAttr("character", character)
                         .with(csrf())
                         .with(oauth2Login().attributes(attr -> attr.put("name", "displayName"))))
@@ -84,7 +84,7 @@ public class CharacterManagementControllerTest {
         final String characterName = "testCharacterName";
         var character = new WildcardCharacter();
         character.setCharacterName(characterName);
-        mockMvc.perform(MockMvcRequestBuilders.post("/createCharacter")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/createCharacter")
                         .flashAttr("character", character)
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());

--- a/src/test/java/popescu/andrei/anfeld/controller/CharacterViewControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/CharacterViewControllerTest.java
@@ -53,7 +53,7 @@ public class CharacterViewControllerTest {
     @Test
     @DirtiesContext
     public void testGetCharactersForUser() throws Exception {
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/characters/" + DEFAULT_USER_ID)
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/characters/" + DEFAULT_USER_ID)
                         .with(csrf())
                         .with(oauth2Login().attributes(attr -> attr.put("name", "displayName"))))
                 .andExpect(status().is2xxSuccessful())
@@ -70,7 +70,7 @@ public class CharacterViewControllerTest {
     @Test
     @DirtiesContext
     public void testGetCharacterWithoutUserUnauthorized() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/characters/user")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/characters/user")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());
     }
@@ -78,7 +78,7 @@ public class CharacterViewControllerTest {
     @Test
     @DirtiesContext
     public void testGetCharacterForOtherUserEmpty() throws Exception {
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/characters/" + DEFAULT_USER_ID + "1")
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/characters/" + DEFAULT_USER_ID + "1")
                         .with(csrf())
                         .with(oauth2Login().attributes(attr -> attr.put("name", "displayName"))))
                 .andExpect(status().is2xxSuccessful())

--- a/src/test/java/popescu/andrei/anfeld/controller/UserControllerTest.java
+++ b/src/test/java/popescu/andrei/anfeld/controller/UserControllerTest.java
@@ -39,7 +39,7 @@ public class UserControllerTest {
     public void testGetUser() throws Exception {
         // the name of the default user is "user"
         // set the name attribute (display name) manually
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/user")
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/api/user")
                         .with(csrf())
                         .with(oauth2Login().attributes(attr -> attr.put("name", "displayName")))
                         .accept(MediaType.APPLICATION_JSON))
@@ -60,7 +60,7 @@ public class UserControllerTest {
     @Test
     @DirtiesContext
     public void testGetUserNotLoggedInUnauthorized() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/user")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/user")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized());
     }


### PR DESCRIPTION
Resolves #12.

Whitelabel error page has been replaced with a custom error page that matches the site's look. Specific variants have also been made for 404 and 401 errors, which one is shown is handled by the `ApplicationErrorController`.

REST endpoints have now been moved under `/api`: any such endpoints will return 401 and redirect to the 401 error page when authentication is needed.
Non-REST endpoints will now redirect the user to login via GitHub if authentication is needed, instead of giving a 401 error page.